### PR TITLE
added Linux instructions to desktop/cli

### DIFF
--- a/docs/desktop/cli.md
+++ b/docs/desktop/cli.md
@@ -27,5 +27,5 @@ alias keys="/tmp/.mount_Keys-*/resources/bin/keys"
 alias keysd="/tmp/.mount_Keys-*/resources/bin/keysd"
 ```
 
-* You should keep the AppImage open in the background
-* There might be unintended consequences to having multiple AppImages open in the background
+* You should preferably keep the AppImage open in the background (it seems to work when not open but has not been tested for all possible cases)
+* There *might* be unintended consequences to having multiple AppImages open in the background 

--- a/docs/desktop/cli.md
+++ b/docs/desktop/cli.md
@@ -20,6 +20,12 @@ TODO
 
 ## Linux
 
+Add the following lines to your .bashrc(or equivalent file)
+
 ```
-TODO
+alias keys="/tmp/.mount_Keys-*/resources/bin/keys"
+alias keysd="/tmp/.mount_Keys-*/resources/bin/keysd"
 ```
+
+* You should keep the AppImage open in the background
+* There might be unintended consequences to having multiple AppImages open in the background


### PR DESCRIPTION
Hi,
This is something that works to use the command line from the desktop version of the app on Linux. This is not an ideal solution because it has a few caveats regarding the AppImage being open, but it seems to mostly work.

I didn't setup a Vuepress environment, so I wasn't able to test the formatting of the changes.

Thanks for making keys.pub