### PR TITLE
Adds arch linux build instructions using the AUR

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -47,3 +47,7 @@ wget -qO - https://storage.googleapis.com/aptly.keys.pub/keys.asc | sudo apt-key
 sudo apt-get update
 sudo apt-get install keys
 ```
+
+## Arch Linux
+
+Available in the AUR as [keys-pub-git](https://aur.archlinux.org/packages/keys-pub-git/)


### PR DESCRIPTION
Hey @gabriel,

I really like where keys.pub is headed.  I created an arch package that builds from the latest tag.  You can check out the PKGBUILD [here[(https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=keys-pub-git).

Keep up the good work.

